### PR TITLE
Use relative font sizes

### DIFF
--- a/project/reference/css/final.css
+++ b/project/reference/css/final.css
@@ -26,24 +26,24 @@ h1, h2 {
   font-weight: normal; /* removes default bold style */
 }
 h1 {
-  font-size: 75px;  
+  font-size: 4.7rem;
 }
 h2{
   color: black;
   font-family: 'Playfair Display', serif;
-  font-size: 56px;
+  font-size: 3.5rem;
   margin-bottom: 30px;
 }
 h3{
   color: black;
 }
 p{
-  font-size: 24px;
+  font-size: 1.5rem;
   line-height: 1.5; /* adjusts space between the lines */
   margin:0;
 }
 ul{
-  font-size: 20px;
+  font-size: 1.3rem;
   line-height: 1.5;
 }
 a {
@@ -56,7 +56,7 @@ a:hover {
   background: white;
   border: 2px solid #0e6c5c;
   color: #0e6c5c;
-  font-size: 22px;
+  font-size: 1.4rem;
   padding: 10px 16px;
   text-decoration: none;
   transition-duration: 0.3s;
@@ -93,12 +93,12 @@ header {
   margin: 0;
 }
 header h1 {
-  font-size: 100px;
+  font-size: 6.3rem;
   font-family: 'Playfair Display', serif;
   padding-bottom: 20px;
 }
 header h2 {
-  font-size: 32px;
+  font-size: 2rem;
   font-family: 'Work Sans', sans-serif;
 }
 
@@ -132,7 +132,7 @@ header h2 {
 address{
   display: block;
   margin: 20px 0;
-  font-size: 28px;
+  font-size: 1.8rem;
   font-style: normal;
 }
 
@@ -145,5 +145,5 @@ footer {
 }
 footer a{
   color: #fefefe;
-  font-size: 16px;
+  font-size: 1rem;
 }

--- a/project/reference/css/styles10.css
+++ b/project/reference/css/styles10.css
@@ -18,10 +18,10 @@ h1, h2 {
   font-weight: normal; /* removes default bold style */
 }
 h1 {
-  font-size: 75px;  
+  font-size: 4.7rem;
 }
 p {
-  font-size: 18px;
+  font-size: 1.5rem;
   line-height: 1.5; /* adjusts space between the lines */
 }
 a {
@@ -53,10 +53,10 @@ header {
   background: #CECCCC;
 }
 header h1 {
-  font-size: 100px;
+  font-size: 6.3rem;
 }
 header h2 {
-  font-size: 32px;
+  font-size: 2rem;
 }
 
 

--- a/project/reference/css/styles2.css
+++ b/project/reference/css/styles2.css
@@ -7,18 +7,18 @@ h1, h2 {
   font-weight: normal; /* removes default bold style */
 }
 h1 {
-  font-size: 75px;  
+  font-size: 4.7rem;
 }
 h2{
   color: black;
   font-family: 'Playfair Display', serif;
-  font-size: 56px;
+  font-size: 3.5rem;
 }
 h3{
   color: black;
 }
 p{
-  font-size: 22px;
+  font-size: 1.5rem;
   line-height: 1.5; /* adjusts space between the lines */
 }
 a {
@@ -32,11 +32,11 @@ a:hover {
 /* PAGE HEADER
 -----------------------------------------*/
 header h1 {
-  font-size: 100px;
+  font-size: 6.3rem;
   font-family: 'Playfair Display', serif;
 }
 header h2 {
-  font-size: 32px;
+  font-size: 2rem;
   font-family: 'Work Sans', sans-serif;
 }
 
@@ -53,14 +53,11 @@ section{
   max-width: 600px;
   margin: 20px auto 0;
 }
-.mission ul{
-  font-size: ;
-}
 
 /* Contact
 -----------------------------------------*/
 address{
-  font-size: 28px;
+  font-size: 1.8rem;
   font-style: normal;
 }
 
@@ -72,5 +69,5 @@ footer {
 }
 footer a{
   color: #fff;
-  font-size: 16px;
+  font-size: 1rem;
 }

--- a/project/reference/css/styles3.css
+++ b/project/reference/css/styles3.css
@@ -7,18 +7,18 @@ h1, h2 {
   font-weight: normal; /* removes default bold style */
 }
 h1 {
-  font-size: 75px;  
+  font-size: 4.7rem;
 }
 h2{
   color: black;
   font-family: 'Playfair Display', serif;
-  font-size: 56px;
+  font-size: 3.5rem;
 }
 h3{
   color: black;
 }
 p{
-  font-size: 22px;
+  font-size: 1.5rem;
   line-height: 1.5; /* adjusts space between the lines */
 }
 a {
@@ -32,7 +32,7 @@ a:hover {
 .button{
   background: white;
   color: #0e6c5c;
-  font-size: 22px;
+  font-size: 1.4rem;
   text-decoration: none;
   transition-duration: 0.3s; /* to make a smooth transition - length in seconds */
 }
@@ -44,11 +44,11 @@ a:hover {
 /* PAGE HEADER
 -----------------------------------------*/
 header h1 {
-  font-size: 100px;
+  font-size: 6.3rem;
   font-family: 'Playfair Display', serif;
 }
 header h2 {
-  font-size: 32px;
+  font-size: 2rem;
   font-family: 'Work Sans', sans-serif;
 }
 
@@ -61,14 +61,11 @@ header h2 {
   max-width: 600px;
   margin: 20px auto 0;
 }
-.mission ul{
-  font-size: ;
-}
 
 /* Contact
 -----------------------------------------*/
 address{
-  font-size: 28px;
+  font-size: 1.8rem;
   font-style: normal;
 }
 
@@ -80,5 +77,5 @@ footer {
 }
 footer a{
   color: #fff;
-  font-size: 16px;
+  font-size: 1rem;
 }

--- a/project/reference/css/styles4.css
+++ b/project/reference/css/styles4.css
@@ -18,19 +18,19 @@ h1, h2 {
   font-weight: normal; /* removes default bold style */
 }
 h1 {
-  font-size: 75px;  
+  font-size: 4.7rem;
 }
 h2{
   color: black;
   font-family: 'Playfair Display', serif;
-  font-size: 56px;
+  font-size: 3.5rem;
   margin-bottom: 30px;
 }
 h3{
   color: black;
 }
 p{
-  font-size: 22px;
+  font-size: 1.5rem;
   line-height: 1.5; /* adjusts space between the lines */
   margin:0;
 }
@@ -46,7 +46,7 @@ a:hover {
   background: white;
   border: 2px solid #0e6c5c;
   color: #0e6c5c;
-  font-size: 22px;
+  font-size: 1.4rem;
   padding: 10px 16px;
   text-decoration: none;
 }
@@ -62,11 +62,11 @@ header{
   margin: 0;
 }
 header h1 {
-  font-size: 100px;
+  font-size: 4.7rem;
   font-family: 'Playfair Display', serif;
 }
 header h2 {
-  font-size: 32px;
+  font-size: 2rem;
   font-family: 'Work Sans', sans-serif;
 }
 
@@ -86,7 +86,7 @@ header h2 {
   width: 80px;
 }
 address{
-  font-size: 28px;
+  font-size: 1.8rem;
   font-style: normal;
   margin: 20px 0;
 }
@@ -100,5 +100,5 @@ footer {
 }
 footer a{
   color: #fff;
-  font-size: 16px;
+  font-size: 1rem;
 }

--- a/project/reference/css/styles5.css
+++ b/project/reference/css/styles5.css
@@ -18,19 +18,19 @@ h1, h2 {
   font-weight: normal; /* removes default bold style */
 }
 h1 {
-  font-size: 75px;  
+  font-size: 4.7rem;
 }
 h2{
   color: black;
   font-family: 'Playfair Display', serif;
-  font-size: 56px;
+  font-size: 3.5rem;
   margin-bottom: 30px;
 }
 h3{
   color: black;
 }
 p{
-  font-size: 22px;
+  font-size: 1.5rem;
   line-height: 1.5; /* adjusts space between the lines */
   margin:0;
 }
@@ -46,7 +46,7 @@ a:hover {
   background: white;
   border: 2px solid #0e6c5c;
   color: #0e6c5c;
-  font-size: 22px;
+  font-size: 1.4rem;
   padding: 10px 16px;
   text-decoration: none;
 }
@@ -65,11 +65,11 @@ header{
   margin: 0;
 }
 header h1 {
-  font-size: 100px;
+  font-size: 4.7rem;
   font-family: 'Playfair Display', serif;
 }
 header h2 {
-  font-size: 32px;
+  font-size: 2rem;
   font-family: 'Work Sans', sans-serif;
 }
 
@@ -94,7 +94,7 @@ header h2 {
   width: 80px;
 }
 address{
-  font-size: 28px;
+  font-size: 1.8rem;
   font-style: normal;
   margin: 20px 0;
 }
@@ -108,5 +108,5 @@ footer {
 }
 footer a{
   color: #fff;
-  font-size: 16px;
+  font-size: 1rem;
 }

--- a/slides-en.html
+++ b/slides-en.html
@@ -1664,8 +1664,25 @@ text-transform: lowercase;</textarea>
       <script type="text/template">
         #What is `rem` and `em`?
 
-        `rem` or `em` are units of measure, like `px` or `%`. The default `font-size` applied by the browser is 16 pixels, which means the two lines below will have the same result:
+        `rem` and `em` are units of measure, like `px` or `%`.
+        `em` is a proportion of the inherited font size of an element, and `rem` is relative to the document's font size.
 
+        Try playing with the demo below to see how relative font sizes work:
+        <textarea class="snippet" data-subject="#css-rel-units">.parent {
+            font-size: 10px;
+          }
+          .child {
+            font-size: 2em;
+          }</textarea>
+
+        <div id="css-rel-units" class="example parent">
+          <p>My font size is 10px!</p>
+          <p class="child">
+            My font size is 2 × 10px, which is 20px!
+          </p>
+        </div>
+
+        The default `font-size` applied to the document is usually around 16 pixels, which means the two lines below will have the same result in most browsers:
         ```
         font-size: 1rem;
         font-size: 16px;

--- a/slides-en.html
+++ b/slides-en.html
@@ -1447,7 +1447,7 @@
         ```
         h2 {
           background-color: green;
-          font-size: 50px;
+          font-size: 3rem;
         }
         ```
         There are many, many CSS properties. New ones are added as old ones being retired (deprecated). No one memorizes them all! Here are some resources to have on hand:
@@ -1880,7 +1880,7 @@ text-transform: lowercase;</textarea>
         .button{
           background: white;
           color: purple;
-          font-size: 22px;
+          font-size: 1.4rem;
           text-decoration: none;
         }
         ```


### PR DESCRIPTION
We should use relative units for font-size in the a11y workshop since it's recommended for accessibility:
https://webaim.org/techniques/fonts/